### PR TITLE
Fix Wear message path

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
       </intent-filter>
       <intent-filter>
         <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
-        <data android:scheme="wear" android:host="*" android:pathPrefix="/request-to-send-response" />
+        <data android:scheme="wear" android:host="*" android:pathPrefix="/request-to-send-responses" />
       </intent-filter>
       <intent-filter>
         <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />


### PR DESCRIPTION
## 原因
Wear 側の AndroidManifest で受信対象に登録していた Message path が、送信側の複数形パスと一致していませんでした。

## 変更内容
wear/src/main/AndroidManifest.xml の /request-to-send-response を /request-to-send-responses に修正しました。

## 実行した検証
- git diff --check
- ./gradlew :wear:assembleDebug