### PR TITLE
Fix Wear message receiver path to /request-to-send-responses

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
       </intent-filter>
       <intent-filter>
         <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
-        <data android:scheme="wear" android:host="*" android:pathPrefix="/request-to-send-response" />
+        <data android:scheme="wear" android:host="*" android:pathPrefix="/request-to-send-responses" />
       </intent-filter>
       <intent-filter>
         <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />


### PR DESCRIPTION
### Motivation
- Align the Wear message receiver path with the sender's plural path so incoming messages are matched and delivered correctly.

### Description
- Update the path prefix in `wear/src/main/AndroidManifest.xml` from `/request-to-send-response` to `/request-to-send-responses`, and make no other file changes.

### Testing
- Ran `git diff --check` which passed; ran `./gradlew :wear:assembleDebug` which exited early due to the environment Java runtime (`25.0.2`) reporting an error and the build failing before compilation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65d46ef4948320b405df2199380af5)