### PR TITLE
PR CIでmobileとwearのDebug APKを検証する

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -49,8 +49,8 @@ jobs:
       - name: Start Http Docker
         run: docker run -p 80:80 -d --name httpbin kennethreitz/httpbin
 
-      - name: Run build
-        run: ./gradlew compileDebugUnitTestJavaWithJavac
+      - name: Build mobile and wear debug APKs
+        run: ./gradlew :mobile:assembleDebug :wear:assembleDebug
   
       - name: Wait for the service to start
         run: |


### PR DESCRIPTION
## 目的

Pull Request CIで、コンパイルとローカル単体テストだけでなく、`mobile` と `wear` のDebug APKが実際に生成できることを最低限検証します。

現行の `compileDebugUnitTestJavaWithJavac` は単体テスト用Javaコンパイルまでが対象で、リソース・Manifest処理、DEX生成、Debug署名、APKパッケージングを完了しません。このため、CI成功時もDebug APKが組み立てられる保証がありませんでした。

## 変更内容

- ビルド手順を `./gradlew :mobile:assembleDebug :wear:assembleDebug` に変更
- 既存の `./gradlew testDebugUnitTest` を維持し、`mobile`・`wear`・`shared`・`AppInfoManager` のローカル単体テストを実行
- 既存のDebug用 `google-services.json` 生成とhttpbin起動・待機設定を維持
- リリースビルド、CI高速化、その他の整理は変更対象外

## 現在のCIで検出できる問題

今回の変更後は、Kotlin・Javaコンパイル、依存解決、Google Services処理、リソースとManifestの処理、重複クラス、DEX生成、Debug署名、APKパッケージングの失敗を `mobile` と `wear` の両方で検出できます。既存のローカル単体テストで再現し、テスト対象になっているロジック不具合も検出できます。

## 現在のCIで検出できない問題

APKを端末へインストールしていないため、インストール時の非互換、Launcher Activity起動後の例外、`onCreate`・ViewModel・Compose初期化中のクラッシュ、端末固有機能やGoogle Play Servicesとの実行時連携不良は検出できません。

既存の `mobile` と `wear` の計装テストはアプリケーションIDの確認のみで、Launcher Activityの起動確認にはなっていません。したがって、過去の「CI成功後に起動しない」問題が実行時クラッシュだった場合、今回のCIでも直接は検出できません。原因がリソース・Manifest・DEX・パッケージングの失敗だった場合は、今回追加したDebug APK組み立てで検出範囲に入ります。

## 起動不能に対する候補策の比較

| 候補 | 検出範囲 | 実行時間 | 安定性 | 保守コスト | 今回 |
| --- | --- | --- | --- | --- | --- |
| Debug APK組み立て | ビルド成果物生成まで | 小 | 高 | 小 | 追加 |
| lint | Manifest、リソース、API利用などの静的問題 | 小〜中 | 高 | 小〜中 | 未追加 |
| エミュレーターへのインストール・起動 | インストール可否と初期起動時の実行時問題 | 大 | 中 | 中〜大 | 別PR候補 |
| Launcher Activityの計装テスト | 起動と初期画面到達をテストとして判定 | 大 | 中 | 大 | 別PR候補 |
| ローカル単体テスト追加 | 切り出してテスト可能な既知原因 | 小 | 高 | 中 | 原因判明後の候補 |

最低限としては、安定して実行でき、現行CIで欠けているAPK生成を今回追加します。実際の起動保証に最も近いのは、mobile用とWear OS用のエミュレーターでインストール後にLauncher Activityを検証する方法です。エミュレーター起動時間、端末イメージ管理、クラッシュ判定方法を決める必要があるため、計測と安定性確認を行う別PRに分ける方針です。

代表的な注意点として、単純な `adb shell am start -W` はコマンド成功直後にアプリプロセスがクラッシュしても成功扱いになる場合があります。追加時の最小ガードは、起動後のプロセス生存または初期画面到達を計装テストで明示的に確認することです。

## 今回追加しなかった検証

- エミュレーターによるインストール・起動確認
- lint
- 起動用の計装テストとローカル単体テスト
- リリースビルド

これらは既存不具合の原因が不明な状態で同時追加すると、実行時間と失敗要因を増やし、今回の最小変更の評価が難しくなるため含めていません。

## 実行した検証

- `./gradlew :mobile:assembleDebug :wear:assembleDebug`
- `HOST=http://localhost ./gradlew testDebugUnitTest`
- `./gradlew :mobile:assembleDebug :wear:assembleDebug testDebugUnitTest --dry-run`
- `actionlint .github/workflows/pr-ci.yaml`
- Ruby YAML parserによる構文確認
- `git diff --check`

すべて成功しました。ローカルで `mobile-debug.apk` と `wear-debug.apk` の生成も確認しました。

GitHub Actionsの `pr-ci` も5分55秒で成功しました。

## GitHub上で確認が必要な事項

- [x] このPRの `pr-ci` が成功し、`:mobile:assembleDebug` と `:wear:assembleDebug` が完了すること
- [x] 同一リポジトリ内のPRで `DEBUG_GOOGLE_SERVICES_JSON` を利用できること
- [x] `main` の必須チェック名 `pr-ci` が本変更後も維持されること
- [ ] 既存ActionのNode.js 20廃止警告への対応方針を、別の保守作業として判断すること

`DEBUG_GOOGLE_SERVICES_JSON` の登録、`main` の必須チェック `pr-ci`、このPRのCI成功を確認済みです。Node.js警告は `actions/cache@v4`、`actions/checkout@v4`、`actions/setup-java@v4`、`dorny/test-reporter@v1` がNode.js 24へ強制実行されているという既存Action由来のもので、今回の差分には含めていません。