### PR TITLE
Migrate deprecated Kotlin compiler options

### DIFF
--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.android)
@@ -49,12 +51,15 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-  kotlinOptions {
-    jvmTarget = "17"
-  }
   buildFeatures {
     compose = true
     buildConfig = true
+  }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_17
   }
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.android)
@@ -21,8 +23,11 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-  kotlinOptions {
-    jvmTarget = "17"
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_17
   }
 }
 

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.android)
@@ -48,11 +50,14 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-  kotlinOptions {
-    jvmTarget = "17"
-  }
   buildFeatures {
     compose = true
+  }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_17
   }
 }
 


### PR DESCRIPTION
## Purpose

Replace the deprecated `android.kotlinOptions` configuration with the typed `kotlin.compilerOptions` DSL supported by the current Kotlin Gradle plugin.

## Changes

- Migrate `mobile`, `wear`, and `shared` to `compilerOptions`
- Keep the Kotlin JVM target at Java 17 with `JvmTarget.JVM_17`
- Leave Java compile options, dependencies, and application code unchanged

## Impact

This is a build configuration migration only. The generated JVM bytecode target remains Java 17.

## Validation

- `git diff --check`
- Pull Request CI: success
  - `./gradlew :mobile:assembleDebug :wear:assembleDebug`
  - `./gradlew testDebugUnitTest`

Local Gradle execution could not download the Gradle 8.13 distribution because this workspace blocks access to `services.gradle.org`; the same requested build and test coverage completed successfully in Pull Request CI.