### PR TITLE
Kotlin compilerOptionsを推奨形式へ移行する

### DIFF
--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.android)
@@ -49,12 +51,15 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-  kotlinOptions {
-    jvmTarget = "17"
-  }
   buildFeatures {
     compose = true
     buildConfig = true
+  }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.fromTarget("17")
   }
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.android)
@@ -21,8 +23,11 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-  kotlinOptions {
-    jvmTarget = "17"
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.fromTarget("17")
   }
 }
 

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.android)
@@ -48,11 +50,14 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-  kotlinOptions {
-    jvmTarget = "17"
-  }
   buildFeatures {
     compose = true
+  }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.fromTarget("17")
   }
 }
 


### PR DESCRIPTION
## 目的

Kotlin Gradle Plugin 2.2.10で非推奨の `android.kotlinOptions` を、Kotlin公式が推奨する型付きの `kotlin.compilerOptions` へ移行します。

[Kotlin公式の移行ガイド](https://kotlinlang.org/docs/gradle-compiler-options.html#migrate-away-from-android-kotlinoptions)に従い、JVMターゲット17の挙動は維持します。

## 確認した構成

- Gradle: 8.13
- Android Gradle Plugin: 8.12.2
- Kotlin Gradle Plugin: 2.2.10
- Java source/target compatibility: 17
- Kotlin JVM target: 17

該当箇所は `mobile`、`wear`、`shared`、Gitサブモジュール `AppInfoManager` の4箇所でした。4箇所とも従来の `kotlinOptions { jvmTarget = "17" }` 形式です。

## 変更内容

WearLink側の次の3モジュールを最小差分で変更しました。

- `mobile/build.gradle.kts`
- `wear/build.gradle.kts`
- `shared/build.gradle.kts`

各モジュールで `org.jetbrains.kotlin.gradle.dsl.JvmTarget` をimportし、Androidブロック内の設定をトップレベルの次の形式へ移行しています。

```kotlin
kotlin {
  compilerOptions {
    jvmTarget = JvmTarget.fromTarget("17")
  }
}
```

Java側の `compileOptions` はKotlinとJavaのJVMターゲット整合性を維持するため変更していません。依存関係、アプリケーションコード、Gradle・プラグインのバージョンも変更していません。

## AppInfoManagerについて

`AppInfoManager` は独立したGitサブモジュールのため、WearLink側の依頼としては変更していません。サブモジュール内の `AppInfoManager/build.gradle.kts` には同じ非推奨記述が1箇所残ります。

AppInfoManager側も移行する場合は、サブモジュールのリポジトリで別変更として扱い、その後に必要であればWearLink側の参照コミット更新を分離して行う必要があります。

## 挙動への影響

KotlinのJVMターゲットは移行前後とも17であり、生成するバイトコードの対象は変わりません。ビルド設定APIだけの移行です。

代表的な破綻パターンは、KotlinのJVMターゲットだけを変更してJavaの `targetCompatibility` と不一致にすることです。今回は両方を17のまま維持し、ルートのDebugビルドで整合性を確認しています。

## 実行した検証

- `./gradlew :mobile:assembleDebug :wear:assembleDebug --warning-mode=all`: 成功
- `./gradlew assembleDebug --warning-mode=all`: 成功
  - `mobile-debug.apk`: 生成確認
  - `wear-debug.apk`: 生成確認
  - `shared-debug.aar`: 生成確認
  - `AppInfoManager-debug.aar`: 生成確認
- `HOST=http://localhost ./gradlew testDebugUnitTest --warning-mode=all`: 成功
  - `AppInfoManager`
  - `mobile`
  - `shared`
  - `wear`
- `./gradlew :mobile:assembleDebug :wear:assembleDebug testDebugUnitTest --dry-run`: 成功
- `git diff --check`: 成功

既存のAndroid Manifest警告は出力されますが、今回変更したWearLink側3モジュールから `kotlinOptions` の非推奨警告は出ていません。