### PR TITLE
Restrict Wear HTTP activity access

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
       android:excludeFromRecents="true"
       android:launchMode="singleTask"
       android:noHistory="true"
+      android:permission="com.google.android.wearable.permission.BIND_TILE_PROVIDER"
       android:theme="@android:style/Theme.DeviceDefault" />
 
     <activity


### PR DESCRIPTION
## 概要

Wear側の`HttpExecuteActivity`はTileから直接起動するため、`android:exported="true"`を維持する必要があります。一方、権限制約がなく、外部アプリが明示的Intentで任意のHTTPリクエストを確認なしに実行できる状態でした。

`HttpExecuteActivity`にWear OSのTile provider bind permissionを設定し、正規経路を維持しながら一般アプリからの直接起動を遮断します。

Closes #219

## 調査結果

### 正規の起動経路

- Tile: `ClickAction.requestExecute`が`LaunchAction`で`HttpExecuteActivity`を直接起動します。Wear OSのTileは別プロセスで描画・操作されるため、この方式では対象Activityの公開が必要です。
- Complication: `ComplicationService`がアプリ自身の明示的Intentから不変の`PendingIntent`を作成し、`HttpExecuteActivity`を起動します。この経路では実行前の確認画面を表示します。

### 外部Intentから渡せた入力

- `requestParams`: タイトル、URL、HTTPメソッド、本文形式、ヘッダー、パラメーターを含むJSON
- `requestTitle`: 実行画面に表示するタイトル
- `showConfirmation`: 確認画面の表示有無

`showConfirmation`の既定値は`false`で、`requestParams`は検証なしに`HttpRequester.execute`へ渡されていました。そのため、外部アプリがActivityを明示的Intentで起動すると、任意のURL・HTTPメソッド・ヘッダー・本文によるリクエストをWearLinkの権限で送信できました。

## 変更内容

- `HttpExecuteActivity`に`com.google.android.wearable.permission.BIND_TILE_PROVIDER`を要求
- `android:exported="true"`、Tileの直接起動、Complicationの不変`PendingIntent`、既存の確認画面の挙動は維持
- Wear OSのTileホスト以外の一般アプリからのActivity起動は権限検査で拒否

## 影響

ユーザーが設定済みのTileおよびComplicationからHTTPリクエストを実行する既存機能は維持されます。一般アプリから、任意のIntent extrasを渡してHTTPリクエストを実行する経路のみを遮断します。

## 検証

成功:

- `xmllint --noout wear/src/main/AndroidManifest.xml`
- `git diff --check`

実行できなかった検証:

- `ANDROID_HOME=/Users/iwai/Library/Android/sdk ./gradlew :wear:assembleDebug :wear:testDebugUnitTest`
  - 秘密ファイル`wear/google-services.json`が作業環境に存在せず、`:wear:processDebugGoogleServices`で失敗しました。ダミーファイルの作成やビルド設定の迂回は行っていません。
- `ANDROID_HOME=/Users/iwai/Library/Android/sdk ./gradlew :wear:processDebugMainManifest`
  - 同じく`wear/google-services.json`不足により`:wear:processDebugGoogleServices`で失敗しました。