### PR TITLE
本番リリースWorkflowのタグ検証を修正

### DIFF
--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -10,17 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       
       - name: Verify tags
         run: |
-          LATEST_ALPHA_TAG=$(git tag -l 'alpha*' | sort -V | tail -n 1)
-          LATEST_V_TAG=$(git tag -l 'v*' | sort -V | tail -n 1)
+          LATEST_INTERNAL_TAG=$(git tag -l 'v*' | sort -V | tail -n 1)
 
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            if [[ -z "$LATEST_ALPHA_TAG" || "$LATEST_V_TAG" != "$GITHUB_REF" ]]; then
-              echo "The latest v tag is being pushed without the latest alpha tag or the alpha tag does not exist."
-              exit 1
-            fi
+          if [[ -z "$LATEST_INTERNAL_TAG" ]]; then
+            echo "The internal release tag does not exist."
+            exit 1
+          fi
+
+          if [[ "$(git rev-list -n 1 "$LATEST_INTERNAL_TAG")" != "$(git rev-parse HEAD)" ]]; then
+            echo "The release tag does not point to the same commit as the latest internal release tag."
+            exit 1
           fi
 
       - name: Notify Error to Slack


### PR DESCRIPTION
## 目的

Productionへの意図しない昇格を防ぐため、本番リリースWorkflowのタグ検証を現在のリリース手順に合わせます。

Closes #218

## 現在のリリース手順

- `v*`タグのpushでInternalリリースWorkflowが起動し、mobileとwearのAABをGoogle PlayのInternalトラックへ登録します。
- `release*`タグのpushでProductionリリースWorkflowが起動し、Fastlaneの`promote_internal_to_production`でInternalトラックのリリースをProductionへ昇格します。

## 原因

ProductionリリースWorkflowは`release*`タグで起動するよう変更されていましたが、検証処理には旧`alpha*`タグの参照と`v*`タグ向けの条件分岐が残っていました。そのため、`release*`タグでは検証条件に入らず、Production昇格が常に検証を素通りする状態でした。また、checkoutが浅いため、比較対象となる過去のタグを取得できない構成でした。

## 変更内容

- ProductionリリースWorkflowで全履歴とタグを取得します。
- 最新の`v*`タグが存在しない場合はProduction昇格を停止します。
- `release*`タグのコミットが最新の`v*`タグのコミットと一致しない場合はProduction昇格を停止します。
- 既存のタグ命名規則と`sort -V`による最新タグ判定は変更しません。

## 影響

最新のInternalリリースと同じコミットに`release*`タグを付けた場合だけ、Productionへの昇格が進みます。タグ名の新しい対応規則は追加していません。

## 検証

- `git diff --check`
- Ruby Psychによる`.github/workflows/release-production.yaml`のYAML構文解析
- `ruby -c fastlane/Fastfile`
- Workflow内の実際のシェルブロックを一時Gitリポジトリで実行
  - `v*`タグなし: 失敗
  - 最新`v*`タグと同一コミット: 成功
  - 最新`v*`タグと別コミット: 失敗
  - より新しい`v*`タグと同一コミット: 成功

## 未実施

- `bundle exec fastlane lanes`
  - ローカルにFastlane関連gemがなく、`bundle install`は`index.rubygems.org`へ接続できなかったため実行できませんでした。Fastfile自体の構文確認は成功しています。