### PR TITLE
OkHttpのinternal API依存を解消する

### DIFF
--- a/shared/src/main/java/info/bvlion/wearlink/request/HttpRequester.kt
+++ b/shared/src/main/java/info/bvlion/wearlink/request/HttpRequester.kt
@@ -10,7 +10,6 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.internal.http.HttpMethod
 import org.json.JSONObject
 import java.util.Date
 
@@ -22,10 +21,11 @@ class HttpRequester {
     isMobile: Boolean = true
   ): ResponseParams = withContext(Dispatchers.IO) {
     val start = System.currentTimeMillis()
+    val isRequestBodyPermitted = params.method != Constant.HttpMethod.GET
 
     val request = Request.Builder()
       .url(
-        if (HttpMethod.permitsRequestBody(params.method.toString()) || params.parameters.isEmpty()) {
+        if (isRequestBodyPermitted || params.parameters.isEmpty()) {
           params.url
         } else {
           "${params.url}?${params.parameters}"
@@ -33,7 +33,7 @@ class HttpRequester {
       )
       .method(
         params.method.toString(),
-        if (HttpMethod.permitsRequestBody(params.method.toString())) {
+        if (isRequestBodyPermitted) {
           params.parameters.toByteArray().let {
             it.toRequestBody(
               if (params.bodyType == Constant.BodyType.JSON) {


### PR DESCRIPTION
## 背景

`HttpRequester` が、公開互換性を保証されない `okhttp3.internal.http.HttpMethod.permitsRequestBody` をURLへのクエリ付与判定とRequestBody生成判定に使用していました。

## 変更内容

- `okhttp3.internal.http.HttpMethod` のimportを削除
- アプリで定義済みのHTTPメソッドに基づき、GET以外でRequestBodyを許可する判定へ置換
- GETは従来どおりパラメーターをクエリへ付与し、POST・PUT・PATCH・DELETEは従来どおりRequestBodyへ設定
- OkHttpを含む依存関係の更新は不要なため未変更

OkHttp 5.1.0の `permitsRequestBody` はGETとHEADのみを除外します。本アプリのHTTPメソッドはGET・POST・PUT・PATCH・DELETEでHEADを含まないため、GET以外というアプリ側判定で既存挙動を維持できます。

## 影響

公開APIではないOkHttp実装詳細への依存を解消し、今後のOkHttp更新によるビルド・動作破綻のリスクを減らします。リクエスト生成挙動の変更はありません。

## 検証

- `ANDROID_HOME=/Users/iwai/Library/Android/sdk HOST=http://localhost ./gradlew :shared:testDebugUnitTest`：成功
  - GETのクエリ送信
  - POST・PUT・PATCH・DELETEのフォーム／JSON RequestBody送信
  - 全5メソッドのヘッダー、ステータスコード
- `git diff --check`：成功
- `okhttp3.internal` の参照検索：対象参照なし
- `ANDROID_HOME=/Users/iwai/Library/Android/sdk ./gradlew :mobile:assembleDebug :wear:assembleDebug`：未完了
  - `mobile/google-services.json` が未配置のためmobile側で失敗
- `ANDROID_HOME=/Users/iwai/Library/Android/sdk ./gradlew :wear:assembleDebug`：未完了
  - `wear/google-services.json` が未配置のため失敗

秘密ファイルのダミー作成やビルド設定の迂回は行っていません。

Closes #220