### PR TITLE
GitHub Actions依存をDependabotの管理対象に追加する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
       time: "09:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 15
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 15

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 15
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/shared-setup"
     schedule:
       interval: "daily"
       time: "09:00"

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -8,8 +8,7 @@ on:
       - '**.kts'
       - '**.properties'
       - 'gradle/libs.versions.toml'
-      - '.github/workflows/dependabot-auto-merge.yaml'
-      - '.github/workflows/pr-ci.yaml'
+      - '.github/workflows/**'
 
 permissions:
   id-token: write

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -8,6 +8,7 @@ on:
       - '**.kts'
       - '**.properties'
       - 'gradle/libs.versions.toml'
+      - '.github/actions/**'
       - '.github/workflows/**'
 
 permissions:


### PR DESCRIPTION
## 目的

Issue #221 に対応し、リポジトリで利用しているGitHub Actions依存をDependabotの更新対象にします。既存Actionの一括更新やNode.jsランタイム警告だけを消す変更は含めません。

Closes #221

## 現在の更新管理

変更前の `.github/dependabot.yml` はGradle依存だけを日次で確認しており、GitHub Actions依存は自動更新の対象外でした。

現在利用している外部Actionは次の9種類です。

- `actions/checkout@v4`
- `actions/setup-java@v4`
- `actions/cache@v4`
- `actions/setup-node@v4`
- `ruby/setup-ruby@v1`
- `dorny/test-reporter@v1`
- `JamesIves/github-pages-deploy-action@4.0.0`
- `8398a7/action-slack@v3`
- `dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0`

また、release・listing WorkflowからローカルComposite Action `./.github/actions/shared-setup` を参照しています。このローカル参照自体は更新対象ではありませんが、Composite Action内の `ruby/setup-ruby` と `actions/cache` は外部依存です。

## 変更内容

- `.github/dependabot.yml` に `github-actions` ecosystemを追加
- `directories` で次の両方を更新対象に指定
  - `/`: `.github/workflows` 内のWorkflow
  - `/.github/actions/shared-setup`: Composite Action
- 既存Gradle設定と同じ日次・09:00（Asia/Tokyo）・最大15件を適用
- `pr-ci.yaml` のパス条件を `.github/workflows/**` と `.github/actions/**` に拡張

Dependabotのgroup設定は追加していないため、更新は原則として依存・対象ディレクトリごとのPull Requestになります。同じActionがWorkflowとComposite Actionの両方にある場合も、横断group化は行いません。

## 既存patch auto-mergeとの関係

既存の `dependabot-auto-merge.yaml` はecosystemを限定していないため、新しく作成されるGitHub Actions Dependabot Pull Requestにも適用されます。

auto-mergeが有効になるのは、次をすべて満たす場合だけです。

- 作成者が `dependabot[bot]`
- 対象リポジトリが `bvlion/WearLink`
- `dependabot/fetch-metadata` の `update-type` が `version-update:semver-patch`
- Pull Requestが新しく `opened` された場合

minor、major、更新種別不明はauto-merge対象外です。また、auto-mergeを有効化しても、既存ブランチ保護の必須 `pr-ci` と承認1件を満たすまでマージされません。自動Approveは行いません。

## Workflow変更時のCI

変更前は `pr-ci.yaml` と `dependabot-auto-merge.yaml` の変更だけがPull Request CI対象で、release・listing・privacy policy Workflow内のAction更新では `pr-ci` が起動しませんでした。

今回のパス条件により、次の変更で既存 `pr-ci` が起動します。

- `.github/workflows/**`
- `.github/actions/**`

直近のDependabot Pull Request #185では、同じ `Pull Request CI` が成功してから承認・マージされていることも確認しました。

代表的な破綻パターンは、Workflowを個別列挙したまま新しいWorkflowを追加し、そのAction更新だけCI対象から漏れることです。最小ガードとしてディレクトリ単位のパス条件を使用します。

## 検証

成功:

- Ruby YAML parserで全6 Workflowの構文を確認
- Ruby YAML parserでDependabot設定のecosystem、2ディレクトリ、schedule、上限値を確認
- `pr-ci.yaml` に `.github/workflows/**` と `.github/actions/**` が含まれることを確認
- `git diff --check`
- GitHub上のremote比較で変更が2ファイルだけであり、branchが `main` より2コミット進み、遅れがないことを確認
- Dependabot Pull Request #185の `Pull Request CI` 成功を確認
- このPull Request #236の `Pull Request CI` が起動し、mobile・wearのDebug APK組み立て、単体テスト、テストレポートを含む全ステップが成功

未実施:

- `actionlint`: ローカル環境に未導入。導入のため実行した `brew install actionlint` はHomebrew配下が書き込み不可のため失敗
