### PR TITLE
Firebase BoM 34対応でCrashlytics KTX依存をfirebase-crashlyticsへ移行

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ activityCompose = "1.13.0"
 composeBom = "2026.06.01"
 wearable = "20.0.1"
 datastore = "1.1.7"
-firebaseBom = "33.16.0"
+firebaseBom = "34.17.0"
 okhttpBom = "5.4.0"
 kotlinxCoroutines = "1.11.0"
 wearRemoteInteractions = "1.1.0"
@@ -44,7 +44,7 @@ play-services-wearable = { group = "com.google.android.gms", name = "play-servic
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
-firebase-crashlytics-ktx = { group = "com.google.firebase", name = "firebase-crashlytics-ktx" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
   implementation(libs.androidx.work.runtime.ktx)
   implementation(libs.play.services.wearable)
   implementation(platform(libs.firebase.bom))
-  implementation(libs.firebase.crashlytics.ktx)
+  implementation(libs.firebase.crashlytics)
   implementation(libs.androidx.lifecycle.runtime.ktx)
   implementation(platform(libs.androidx.compose.bom))
   implementation(libs.datastore.preferences)

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
   implementation(platform(libs.androidx.compose.bom))
 
   implementation(platform(libs.firebase.bom))
-  implementation(libs.firebase.crashlytics.ktx)
+  implementation(libs.firebase.crashlytics)
 
   add("kotlinCompilerPluginClasspath", libs.kotlin.parcelize.compiler)
 

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -77,7 +77,7 @@ dependencies {
   implementation(libs.core.splashscreen)
 
   implementation(platform(libs.firebase.bom))
-  implementation(libs.firebase.crashlytics.ktx)
+  implementation(libs.firebase.crashlytics)
   implementation(libs.androidx.lifecycle.runtime.ktx)
   implementation(platform(libs.androidx.compose.bom))
   implementation(libs.datastore.preferences)


### PR DESCRIPTION
Closes #262

## 原因

Dependabot PR #261（Firebase BoMを`33.16.0`→`34.17.0`へ更新）のCIで、Debug APKビルドが以下のエラーで失敗していた。

```
Execution failed for task ':mobile:processDebugNavigationResources'.
> Could not resolve all files for configuration ':mobile:debugRuntimeClasspath'.
   > Could not find com.google.firebase:firebase-crashlytics-ktx:.
     Required by:
         project ':mobile'
         project ':mobile' > project :shared
```

Firebase Android SDKはBoM 32系以降KTXモジュールを本体モジュールへ統合しており、Firebase BoM 34ではBoMのバージョン制約表から`firebase-crashlytics-ktx`が削除されている。そのため、バージョン指定なし（空文字）でのみ`firebase-crashlytics-ktx`を要求する既存の依存定義が解決不能になっていた。

`shared`・`mobile`・`wear`のいずれも`gradle/libs.versions.toml`の`firebase-crashlytics-ktx`エイリアス（`com.google.firebase:firebase-crashlytics-ktx`、BoMからバージョン取得）経由でCrashlyticsに依存していた。

## 変更内容

- `gradle/libs.versions.toml`
  - `firebaseBom` を `33.16.0` → `34.17.0` に更新
  - `firebase-crashlytics-ktx`エイリアスを、Firebase BoM 34でも解決可能な本体モジュール`com.google.firebase:firebase-crashlytics`を指す`firebase-crashlytics`エイリアスに置き換え
- `mobile/build.gradle.kts` / `wear/build.gradle.kts` / `shared/build.gradle.kts`
  - `libs.firebase.crashlytics.ktx` への参照を `libs.firebase.crashlytics` に変更

### Kotlinコード側は変更なし

Crashlyticsの利用箇所は`shared/src/main/java/info/bvlion/wearlink/request/WearMobileConnector.kt`の1箇所のみで、`import com.google.firebase.crashlytics.FirebaseCrashlytics` と `FirebaseCrashlytics.getInstance().recordException(exception)` という素のJava APIのみを使用しており、`Firebase.crashlytics`のようなKTX固有の拡張関数には依存していなかった。そのため依存モジュールの差し替えのみで移行が完結する。

## 検証

- `./gradlew :mobile:assembleDebug :wear:assembleDebug` → BUILD SUCCESSFUL
- `HOST=http://localhost ./gradlew testDebugUnitTest`（httpbinコンテナ起動の上で実行） → BUILD SUCCESSFUL
- `git diff --check` → 問題なし
- 実機（Pixel 3a XL、adb接続）にmobile Debug APKをインストールし起動確認
  - `FirebaseCrashlytics: Initializing Firebase Crashlytics 20.1.0 for info.bvlion.wearlink.debug` のログを確認
  - `FATAL EXCEPTION`等のクラッシュログなし、プロセスが起動後も生存していることを確認
  - 検証後はアプリをアンインストール済み
- wearアプリの実機起動確認は、接続可能なWear OS端末が手元になかったため未実施。ただしCrashlytics関連コードはmobileと同じ`shared`モジュールを参照しており、`:wear:assembleDebug`のビルド成功によりモジュール解決自体は確認済み。

## 未実施事項

- Wear OS実機（またはエミュレーター）上での起動時クラッシュ確認は環境上の制約により未実施。

## 関連

- Dependabot PR #261 はこのPRのマージ後にCloseしてください（本PRの変更で内容が置き換わるため、自動Closeはしていません）。