### PR TITLE
同期対象0件でもWear側でJSONArray解析に失敗しないよう修正

### DIFF
--- a/mobile/src/main/java/info/bvlion/wearlink/sync/Sync.kt
+++ b/mobile/src/main/java/info/bvlion/wearlink/sync/Sync.kt
@@ -2,24 +2,19 @@ package info.bvlion.wearlink.sync
 
 import info.bvlion.wearlink.data.AppDataStore
 import info.bvlion.wearlink.data.RequestParams.Companion.parseRequestParams
+import info.bvlion.wearlink.data.RequestParams.Companion.toRequestParamsJson
 import info.bvlion.wearlink.request.WearMobileConnector
 import kotlinx.coroutines.flow.first
-import org.json.JSONArray
 
 object Sync {
   suspend fun requestsSyncToWear(dataStore: AppDataStore, wearConnector: WearMobileConnector) {
-    val watchSavedRequests = dataStore.getSavedRequest.first()?.let { value ->
-      value.parseRequestParams()
-        .filter { it.watchSync || it.watchfaceShortcut }
-        .map { it.toJsonString() }
-        .let {
-          if (it.isEmpty()) {
-            byteArrayOf()
-          } else {
-            JSONArray(it).toString().toByteArray()
-          }
-        }
-    } ?: byteArrayOf()
-    wearConnector.sendMessageToWear(WearMobileConnector.WEAR_SAVE_REQUEST_PATH, watchSavedRequests)
+    val watchTargetRequests = dataStore.getSavedRequest.first()
+      ?.parseRequestParams()
+      ?.filter { it.watchSync || it.watchfaceShortcut }
+      ?: emptyList()
+    wearConnector.sendMessageToWear(
+      WearMobileConnector.WEAR_SAVE_REQUEST_PATH,
+      watchTargetRequests.toRequestParamsJson().toByteArray()
+    )
   }
 }

--- a/shared/src/main/java/info/bvlion/wearlink/data/RequestParams.kt
+++ b/shared/src/main/java/info/bvlion/wearlink/data/RequestParams.kt
@@ -36,6 +36,12 @@ data class RequestParams(
     private const val PARAMETERS = "parameters"
     private const val WATCH_SYNC = "watchSync"
     private const val WATCH_FACE_SHORTCUT = "watchfaceShortcut"
+    private const val EMPTY_JSON_ARRAY = "[]"
+
+    fun List<RequestParams>.toRequestParamsJson(): String =
+      JSONArray(map { it.toJsonString() }).toString()
+
+    fun String.normalizeRequestParamsJson(): String = if (isBlank()) EMPTY_JSON_ARRAY else this
 
     fun String.parseRequestParams(): List<RequestParams> {
       val list = mutableListOf<RequestParams>()

--- a/shared/src/test/java/info/bvlion/wearlink/data/RequestParamsTest.kt
+++ b/shared/src/test/java/info/bvlion/wearlink/data/RequestParamsTest.kt
@@ -1,0 +1,62 @@
+package info.bvlion.wearlink.data
+
+import info.bvlion.wearlink.data.RequestParams.Companion.normalizeRequestParamsJson
+import info.bvlion.wearlink.data.RequestParams.Companion.parseRequestParams
+import info.bvlion.wearlink.data.RequestParams.Companion.toRequestParamsJson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RequestParamsTest {
+  private val watchSyncRequest = RequestParams(
+    title = "watch sync request",
+    url = "https://example.com/sync",
+    method = Constant.HttpMethod.GET,
+    bodyType = Constant.BodyType.QUERY,
+    watchSync = true
+  )
+  private val watchfaceShortcutRequest = RequestParams(
+    title = "watchface shortcut request",
+    url = "https://example.com/shortcut",
+    method = Constant.HttpMethod.POST,
+    bodyType = Constant.BodyType.JSON,
+    watchfaceShortcut = true
+  )
+
+  @Test
+  fun toRequestParamsJsonEmptyListTest() {
+    assertEquals("[]", emptyList<RequestParams>().toRequestParamsJson())
+  }
+
+  @Test
+  fun parseRequestParamsEmptyJsonArrayTest() {
+    assertTrue("[]".parseRequestParams().isEmpty())
+  }
+
+  @Test
+  fun toRequestParamsJsonRoundTripTest() {
+    val requests = listOf(watchSyncRequest, watchfaceShortcutRequest)
+
+    val actual = requests.toRequestParamsJson().parseRequestParams()
+
+    assertEquals(requests, actual)
+  }
+
+  @Test
+  fun normalizeRequestParamsJsonBlankTest() {
+    assertEquals("[]", "".normalizeRequestParamsJson())
+    assertEquals("[]", "   ".normalizeRequestParamsJson())
+  }
+
+  @Test
+  fun normalizeRequestParamsJsonBlankParsesWithoutExceptionTest() {
+    assertTrue("".normalizeRequestParamsJson().parseRequestParams().isEmpty())
+  }
+
+  @Test
+  fun normalizeRequestParamsJsonNonBlankUnchangedTest() {
+    val json = listOf(watchSyncRequest).toRequestParamsJson()
+
+    assertEquals(json, json.normalizeRequestParamsJson())
+  }
+}

--- a/wear/src/main/java/info/bvlion/wearlink/service/MobilesDataListenerService.kt
+++ b/wear/src/main/java/info/bvlion/wearlink/service/MobilesDataListenerService.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import info.bvlion.wearlink.data.AppDataStore
+import info.bvlion.wearlink.data.RequestParams.Companion.normalizeRequestParamsJson
 import info.bvlion.wearlink.data.RequestParams.Companion.parseRequestParams
 import info.bvlion.wearlink.request.WearMobileConnector
 
@@ -26,7 +27,7 @@ class MobilesDataListenerService : WearableListenerService() {
     when (messageEvent.path) {
       WearMobileConnector.WEAR_SAVE_REQUEST_PATH ->
         scope.launch {
-          val requestData = String(messageEvent.data)
+          val requestData = String(messageEvent.data).normalizeRequestParamsJson()
           dataStore.saveRequest(requestData)
           MainTileService.tileUpdate(this@MobilesDataListenerService)
           if (requestData.parseRequestParams().any { it.watchfaceShortcut }) {


### PR DESCRIPTION
Closes #266

## 再現条件

- MobileとWear OSが接続されている
- Mobile側に`watchSync`または`watchfaceShortcut`が有効なRequestが1件もない
- Wear OS側から同期を実行する（実際にはMobile側で`getSavedRequest`の値が変化する度に自動同期されるため、Mobile起動時や最後のwatchSync/watchfaceShortcut対象を解除した時にも同じ経路で再現する）

## 原因

`mobile/src/main/java/info/bvlion/wearlink/sync/Sync.kt`の`requestsSyncToWear()`は、`watchSync`・`watchfaceShortcut`対象が0件のとき、有効なJSON配列`[]`ではなく長さ0の`ByteArray`を送信していた。

`wear/src/main/java/info/bvlion/wearlink/service/MobilesDataListenerService.kt`は受信データを`String(messageEvent.data)`で空文字列に変換した後、無条件に`RequestParams.parseRequestParams()`（内部で`JSONArray(this)`を実行）へ渡していたため、`JSONArray("")`が`JSONException: End of input at character 0 of`を投げていた。

なお、今回同時に更新された`org.json:json`は`shared`モジュールの`testImplementation`専用の依存（テスト時のみ使用）であり、実機・実エミュレーターではAndroid標準の`org.json`が使われるため、この不具合の原因ではない。空データを送信する処理自体は本Issue以前から存在していた。

## Mobile送信側の修正内容

`Sync.kt`で、フィルタ後のリストを`byteArrayOf()`へ特別扱いする分岐を削除し、0件・1件以上を問わず常に`org.json.JSONArray`経由でエンコードするようにした。

```kotlin
val watchTargetRequests = dataStore.getSavedRequest.first()
  ?.parseRequestParams()
  ?.filter { it.watchSync || it.watchfaceShortcut }
  ?: emptyList()
wearConnector.sendMessageToWear(
  WearMobileConnector.WEAR_SAVE_REQUEST_PATH,
  watchTargetRequests.toRequestParamsJson().toByteArray()
)
```

`watchSync`・`watchfaceShortcut`のフィルタ条件、および対象が存在する場合のJSON形式（`JSONArray(List<String>).toString()`）は変更していない。JSONエンコード処理自体は`shared`の`RequestParams.Companion`に`toRequestParamsJson()`として切り出し、Wear側の`parseRequestParams()`と対称な位置に置いた（`Sync`から`org.json`への直接依存も不要になった）。

## Wear受信側の互換対応

`MobilesDataListenerService.kt`で、受信直後に`RequestParams.Companion.normalizeRequestParamsJson()`（`isBlank()`の場合のみ`"[]"`へ置き換え、それ以外はそのまま返す）を通してから`dataStore.saveRequest()`に保存し、同じ正規化後の値を使ってTile更新トリガーとComplication更新判定（`requestData.parseRequestParams().any { it.watchfaceShortcut }`）を行うようにした。

- 空・空白の受信データのみを`[]`に正規化し、空でない不正なJSONはそのまま`parseRequestParams()`に渡して従来どおり例外にする（握り潰さない）
- 保存値とTile/Complication判定に使う値を同一変数（正規化後の`requestData`）に統一

`parseRequestParams()`自体の呼び出し元（`MobileMainActivity`、`MobileMainViewModel`、`MenuCompose`、`MainTileService`、`ComplicationService`）を確認したところ、いずれも`null`または空文字列を呼び出し前に`?.`や`isEmpty()`チェックで避けているか、今回の修正で受信直後に正規化されるため、`parseRequestParams()`本体の仕様変更は行っていない（今回の不具合に不要な広範囲の変更を避けるため）。

## 追加・更新したテスト

`shared/src/test/java/info/bvlion/wearlink/data/RequestParamsTest.kt`を新規追加（6件、全て成功）。

- `toRequestParamsJsonEmptyListTest`: 空リストが`"[]"`にエンコードされること
- `parseRequestParamsEmptyJsonArrayTest`: `"[]"`が空Listにパースされること
- `toRequestParamsJsonRoundTripTest`: `watchSync`/`watchfaceShortcut`を含む複数件のリストがJSONエンコード→パースで元のリストと一致すること（保存・Tile・Complication判定が壊れていないことの回帰確認）
- `normalizeRequestParamsJsonBlankTest`: 空文字列・空白文字列が`"[]"`に正規化されること
- `normalizeRequestParamsJsonBlankParsesWithoutExceptionTest`: 正規化後の値を`parseRequestParams()`しても例外にならず空Listになること
- `normalizeRequestParamsJsonNonBlankUnchangedTest`: 非空のJSONは正規化で変化しないこと

`Sync`・`MobilesDataListenerService`はAndroidフレームワーク（`AppDataStore`／`WearableListenerService`）に依存しており、本リポジトリには元々モックフレームワークやRobolectric等のテスト基盤がないため、テストのためだけにそれらを追加することは避けた。両クラスの核心ロジック（JSON配列のエンコード・デコード・正規化）は`shared`側に最小限切り出し、Android依存なしで直接テストできるようにした。実際の送受信・保存・Tile/Complication連携は下記の実機/エミュレーター確認で検証した。

## 検証

- `HOST=http://localhost ./gradlew testDebugUnitTest`（httpbinコンテナ起動の上で実行）→ BUILD SUCCESSFUL、`RequestParamsTest`の6件含め全テスト成功
- `./gradlew :mobile:assembleDebug` → BUILD SUCCESSFUL
- `./gradlew :wear:assembleDebug` → BUILD SUCCESSFUL
- `git diff --check` → 問題なし

## 実機・エミュレーターでの確認

Android Studioでペアリング済みのWear OSエミュレーター（sdk_gwear_arm64）とスマートフォンエミュレーター（sdk_gphone64_arm64）にDebug APKをインストールし、実際のWearable API経由でMobile→Wearのメッセージ送受信を確認した。

1. **同期対象0件**: 保存済みRequestがない状態でMobileアプリを起動すると、`MobilesDataListenerService`が起動してメッセージを処理した。クラッシュ（`FATAL EXCEPTION`・`JSONException`）は発生せず、Wear側`DataStore`のファイルを直接確認したところ`saved_request = "[]"`が保存されていることを確認した。
2. **同期対象1件以上**: Mobileアプリで`watchfaceShortcut`を有効にしたRequest（`TestSync`）を作成すると自動的にWearへ同期され、クラッシュなく`MobilesDataListenerService`が処理を完了した。Wear側`DataStore`のファイルを直接確認したところ、`saved_request`に`watchfaceShortcut: true`を含む正しいJSON配列（`["{\"title\":\"TestSync\",...,\"watchfaceShortcut\":true}"]`）が保存されていることを確認した。両ケースともTile更新（`ProtoTilesUpdateRequesterService: Updating tile`のログ）がトリガーされていることも確認した。

いずれもDataStoreの永続化ファイルを直接読み出すことで、実際に保存された値レベルで検証している。

## 補足

- Issue #249の対応は本PRに含めていない。