### PR TITLE
Restore Wear tile HTTP activity launch

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -35,7 +35,6 @@
       android:excludeFromRecents="true"
       android:launchMode="singleTask"
       android:noHistory="true"
-      android:permission="com.google.android.wearable.permission.BIND_TILE_PROVIDER"
       android:theme="@android:style/Theme.DeviceDefault" />
 
     <activity


### PR DESCRIPTION
## 内容

Closes #268

- `HttpExecuteActivity`から誤って設定されていた`BIND_TILE_PROVIDER`権限を削除
- `MainTileService`の権限設定は維持

## 確認

- Pull Request CI成功
- Wear OSエミュレーターでTileタップから`HttpExecuteActivity`が起動することを確認
- TileからHTTP通信が実行されることを確認

<!--このPRのレビューコメントは日本語でお願いします。 -->