### PR TITLE
最低ローディング時間制御の簡素化 (mobile/Wear)

### DIFF
--- a/mobile/src/main/java/info/bvlion/wearlink/shortcut/ShortcutExecuteViewModel.kt
+++ b/mobile/src/main/java/info/bvlion/wearlink/shortcut/ShortcutExecuteViewModel.kt
@@ -10,6 +10,7 @@ import info.bvlion.wearlink.data.RequestParams.Companion.parseRequestParams
 import info.bvlion.wearlink.request.HttpRequester
 import info.bvlion.wearlink.request.executeRequest
 import info.bvlion.wearlink.request.hasLocalNetworkAccessPermission
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -37,7 +38,7 @@ sealed interface ShortcutExecuteState {
   data object RequestNotFound : ShortcutExecuteState
 }
 
-private const val MINIMUM_LOADING_MILLIS = 2000L
+private val MINIMUM_LOADING_DURATION = 2.seconds
 
 class ShortcutExecuteViewModel(application: Application) : AndroidViewModel(application) {
   private val dataStore = AppDataStore.getDataStore(application)
@@ -87,7 +88,7 @@ class ShortcutExecuteViewModel(application: Application) : AndroidViewModel(appl
           getString = getString
         )
       }
-      delay(MINIMUM_LOADING_MILLIS)
+      delay(MINIMUM_LOADING_DURATION)
       val response = responseDeferred.await()
 
       dataStore.appendResponse(response)

--- a/mobile/src/main/java/info/bvlion/wearlink/shortcut/ShortcutExecuteViewModel.kt
+++ b/mobile/src/main/java/info/bvlion/wearlink/shortcut/ShortcutExecuteViewModel.kt
@@ -7,13 +7,11 @@ import info.bvlion.wearlink.data.AppConstants
 import info.bvlion.wearlink.data.AppDataStore
 import info.bvlion.wearlink.data.RequestParams.Companion.findById
 import info.bvlion.wearlink.data.RequestParams.Companion.parseRequestParams
-import info.bvlion.wearlink.data.ResponseParams
 import info.bvlion.wearlink.request.HttpRequester
 import info.bvlion.wearlink.request.executeRequest
 import info.bvlion.wearlink.request.hasLocalNetworkAccessPermission
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -80,7 +78,7 @@ class ShortcutExecuteViewModel(application: Application) : AndroidViewModel(appl
 
       _state.value = ShortcutExecuteState.Loading(request.title)
 
-      val networkDeferred = async(Dispatchers.IO) {
+      val responseDeferred = async {
         executeRequest(
           requester,
           request,
@@ -89,13 +87,8 @@ class ShortcutExecuteViewModel(application: Application) : AndroidViewModel(appl
           getString = getString
         )
       }
-      val timerDeferred = async(Dispatchers.IO) {
-        delay(MINIMUM_LOADING_MILLIS)
-      }
-
-      val response = listOf(networkDeferred, timerDeferred).awaitAll()
-        .filterIsInstance<ResponseParams>()
-        .first()
+      delay(MINIMUM_LOADING_MILLIS)
+      val response = responseDeferred.await()
 
       dataStore.appendResponse(response)
 

--- a/wear/src/main/java/info/bvlion/wearlink/httpexecute/HttpExecuteViewModel.kt
+++ b/wear/src/main/java/info/bvlion/wearlink/httpexecute/HttpExecuteViewModel.kt
@@ -8,6 +8,7 @@ import info.bvlion.wearlink.data.RequestParams.Companion.parseRequestParam
 import info.bvlion.wearlink.request.HttpRequester
 import info.bvlion.wearlink.request.executeRequest
 import info.bvlion.wearlink.request.hasLocalNetworkAccessPermission
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -15,7 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-private const val MINIMUM_LOADING_MILLIS = 2000L
+private val MINIMUM_LOADING_DURATION = 2.seconds
 
 class HttpExecuteViewModel(application: Application) : AndroidViewModel(application) {
   private val dataStore = AppDataStore.getDataStore(application)
@@ -41,7 +42,7 @@ class HttpExecuteViewModel(application: Application) : AndroidViewModel(applicat
           getString = getString
         )
       }
-      delay(MINIMUM_LOADING_MILLIS)
+      delay(MINIMUM_LOADING_DURATION)
       val response = responseDeferred.await()
 
       dataStore.appendResponse(response)

--- a/wear/src/main/java/info/bvlion/wearlink/httpexecute/HttpExecuteViewModel.kt
+++ b/wear/src/main/java/info/bvlion/wearlink/httpexecute/HttpExecuteViewModel.kt
@@ -5,17 +5,17 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import info.bvlion.wearlink.data.AppDataStore
 import info.bvlion.wearlink.data.RequestParams.Companion.parseRequestParam
-import info.bvlion.wearlink.data.ResponseParams
 import info.bvlion.wearlink.request.HttpRequester
 import info.bvlion.wearlink.request.executeRequest
 import info.bvlion.wearlink.request.hasLocalNetworkAccessPermission
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+
+private const val MINIMUM_LOADING_MILLIS = 2000L
 
 class HttpExecuteViewModel(application: Application) : AndroidViewModel(application) {
   private val dataStore = AppDataStore.getDataStore(application)
@@ -32,7 +32,7 @@ class HttpExecuteViewModel(application: Application) : AndroidViewModel(applicat
 
     val request = param.parseRequestParam()
     viewModelScope.launch(Dispatchers.IO) {
-      val networkDeferred = async(Dispatchers.IO) {
+      val responseDeferred = async {
         executeRequest(
           requester,
           request,
@@ -41,13 +41,8 @@ class HttpExecuteViewModel(application: Application) : AndroidViewModel(applicat
           getString = getString
         )
       }
-      val timerDeferred = async(Dispatchers.IO) {
-        delay(2000)
-      }
-
-      val response = listOf(networkDeferred, timerDeferred).awaitAll()
-        .filterIsInstance<ResponseParams>()
-        .first()
+      delay(MINIMUM_LOADING_MILLIS)
+      val response = responseDeferred.await()
 
       dataStore.appendResponse(response)
       _isSent.value = true


### PR DESCRIPTION
## 概要

Closes #275

`ShortcutExecuteViewModel`（mobile）と `HttpExecuteViewModel`（Wear）にある「HTTP通信」と「最低ローディング時間(2秒)」のうち遅い方を待つ処理を簡素化しました。

## 変更内容

### 従来の待機処理

```kotlin
val networkDeferred = async(Dispatchers.IO) {
  executeRequest(...)
}
val timerDeferred = async(Dispatchers.IO) {
  delay(2000)
}

val response = listOf(networkDeferred, timerDeferred).awaitAll()
  .filterIsInstance<ResponseParams>()
  .first()
```

`Deferred<ResponseParams>` と `Deferred<Unit>` を同じ `List` にまとめて `awaitAll()` し、`filterIsInstance<ResponseParams>()` で結果を取り出す構成になっており、「通信と最低待機の遅い方まで待つ」という意図に対して回りくどい書き方でした。

### 簡素化後

```kotlin
val responseDeferred = async {
  executeRequest(...)
}
delay(MINIMUM_LOADING_DURATION)
val response = responseDeferred.await()
```

HTTP通信を `async` で先行開始し、その間 `delay(MINIMUM_LOADING_DURATION)` で最低待機し、待機後に `await()` で通信結果を取得する形にしました。型混在も `filterIsInstance` も不要になり、「通信と最低待機の遅い方まで待つ」という意図がコードのまま読めます。

- `ShortcutExecuteViewModel` / `HttpExecuteViewModel` とも親コルーチンが既に `viewModelScope.launch(Dispatchers.IO)` のため、`async(Dispatchers.IO)` の明示的なDispatcher指定は不要と判断し削除しました（Dispatcherは継承されるため実質的な変更はありません）。
- 待機時間の定数は `MINIMUM_LOADING_MILLIS = 2000L`（`Long`）から `MINIMUM_LOADING_DURATION = 2.seconds`（`kotlin.time.Duration`）へ変更しました。`delay()` は `Duration` を受け取るオーバーロードを持つため呼び出し側はそのまま自然に書けます。Wear側にも同じ定数名を追加し、両者の考え方を揃えました。
- 待機処理の共通化のための新しいUseCase/Repository/utility/interface/DIは追加していません（数行の重複を許容）。

### 挙動の維持

- HTTP通信が約300msで完了 → ローディング終了は約2秒（変更なし）
- HTTP通信が約1.5秒で完了 → ローディング終了は約2秒（変更なし）
- HTTP通信が約4秒で完了 → ローディング終了は約4秒、追加の2秒待機なし（変更なし）

`delay()` 完了時点で `responseDeferred` が既に完了していれば `await()` は即座に返るため、従来の `awaitAll()` と等価な待ち合わせになります。

### 変更しないもの

`executeRequest()` / `HttpRequester` / `AppDataStore.appendResponse()` の責務、`ShortcutExecuteState`、Shortcutの二重実行防止、Shortcut UI/Theme/fade-out、Wearの`isSent`、`HttpResult`、Response履歴、`isMobile`、ローカルネットワーク権限処理は一切変更していません。

## テストについて

今回の対象箇所（`ShortcutExecuteViewModel` / `HttpExecuteViewModel`）は既存でもユニットテストが存在せず（`AndroidViewModel`としてApplication contextに依存するため、既存の`shared`テストのようなhttpbin経由のテストでは検証できません）、新規にRobolectric等のテスト基盤を追加することは今回のスコープ外としました。変更内容も標準ライブラリの`async`/`delay`/`await`の組み合わせに置き換えるのみで独自ロジックを追加していないため、実時間で2秒待つテストを新設するコストに見合わないと判断し、テストは追加していません。

## 検証結果

- `HOST=http://localhost ./gradlew testDebugUnitTest` : BUILD SUCCESSFUL
- `./gradlew :mobile:assembleDebug :wear:assembleDebug` : BUILD SUCCESSFUL
- `git diff --check` : 問題なし

## 実機確認について

今回は実機・Wear OSエミュレーターでの確認は行っていません。#274と合わせて、以下を人間側で実機確認予定です。

- Shortcut実行時、300ms/1.5秒/4秒相当のレスポンス時間でローディング終了タイミングが意図通りであること
- Wear側でも同様にローディング終了タイミングが意図通りであること
- Shortcut/Wearそれぞれの二重実行防止・Response履歴保存・UI表示が#274の変更を含めて問題ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TEBPpQW7p2vWXH28zK9fq
